### PR TITLE
feat(video): Add selectable video decoder support

### DIFF
--- a/cmake/moonlight-dependencies.cmake
+++ b/cmake/moonlight-dependencies.cmake
@@ -82,7 +82,7 @@ function(_moonlight_compute_ffmpeg_signature out_var nxdk_dir ffmpeg_source_dir)
     set(signature_inputs
             "FFMPEG_REVISION=${ffmpeg_revision}"
             "NXDK_DIR=${nxdk_dir}"
-            "FFMPEG_PROFILE=h264-opus-xbox"
+            "FFMPEG_PROFILE=h264-mpeg2-h263-opus-xbox"
             "FFMPEG_TARGET_OS=none"
             "FFMPEG_ARCH=x86"
             "FFMPEG_CC_WRAPPER_SHA256=${ffmpeg_cc_wrapper_hash}"
@@ -201,7 +201,13 @@ function(_moonlight_get_ffmpeg_configure_args out_var)
             --enable-swscale
             --enable-swresample
             --enable-parser=h264
+            --enable-parser=h263
+            --enable-parser=mpegvideo
             --enable-decoder=h264
+            --enable-decoder=h263
+            --enable-decoder=h263i
+            --enable-decoder=h263p
+            --enable-decoder=mpeg2video
             --enable-decoder=opus)
 
     set(${out_var} "${ffmpeg_configure_args}" PARENT_SCOPE)

--- a/src/app/client_state.cpp
+++ b/src/app/client_state.cpp
@@ -32,6 +32,12 @@ namespace {
   constexpr int DEFAULT_STREAM_BITRATE_KBPS = 1000;
   constexpr std::array<int, 6> STREAM_FRAMERATE_OPTIONS {15, 20, 24, 25, 30, 60};
   constexpr std::array<int, 9> STREAM_BITRATE_OPTIONS {500, 750, 1000, 1500, 2000, 2500, 3000, 4000, 5000};
+  constexpr std::array<app::VideoDecoderSelection, 4> VIDEO_DECODER_OPTIONS {
+    app::VideoDecoderSelection::autoDetect,
+    app::VideoDecoderSelection::h264,
+    app::VideoDecoderSelection::mpeg2,
+    app::VideoDecoderSelection::h263p,
+  };
 
   /**
    * @brief Describes the keypad characters available for the active add-host field.
@@ -145,6 +151,27 @@ namespace {
   }
 
   /**
+   * @brief Return the settings label for one video decoder preference.
+   *
+   * @param selection Decoder preference to describe.
+   * @return User-facing decoder preference label.
+   */
+  const char *video_decoder_selection_label(app::VideoDecoderSelection selection) {
+    switch (selection) {
+      case app::VideoDecoderSelection::autoDetect:
+        return "Auto";
+      case app::VideoDecoderSelection::h264:
+        return "H.264";
+      case app::VideoDecoderSelection::mpeg2:
+        return "MPEG-2/H.262";
+      case app::VideoDecoderSelection::h263p:
+        return "H.263+";
+    }
+
+    return "Auto";
+  }
+
+  /**
    * @brief Return the selected stream-resolution index inside the detected mode list.
    *
    * @param state Current client state containing the preferred mode.
@@ -211,6 +238,22 @@ namespace {
 
     const std::size_t nextIndex = (static_cast<std::size_t>(std::distance(STREAM_BITRATE_OPTIONS.begin(), current)) + 1U) % STREAM_BITRATE_OPTIONS.size();
     state.settings.streamBitrateKbps = STREAM_BITRATE_OPTIONS[nextIndex];
+  }
+
+  /**
+   * @brief Advance the preferred video decoder to the next supported option.
+   *
+   * @param state Current client state containing the preferred decoder.
+   */
+  void cycle_video_decoder(app::ClientState &state) {
+    const auto current = std::find(VIDEO_DECODER_OPTIONS.begin(), VIDEO_DECODER_OPTIONS.end(), state.settings.videoDecoder);
+    if (current == VIDEO_DECODER_OPTIONS.end()) {
+      state.settings.videoDecoder = app::VideoDecoderSelection::autoDetect;
+      return;
+    }
+
+    const std::size_t nextIndex = (static_cast<std::size_t>(std::distance(VIDEO_DECODER_OPTIONS.begin(), current)) + 1U) % VIDEO_DECODER_OPTIONS.size();
+    state.settings.videoDecoder = VIDEO_DECODER_OPTIONS[nextIndex];
   }
 
   std::string pairing_reset_endpoint_key(std::string_view address, uint16_t port) {
@@ -542,6 +585,12 @@ namespace {
             "cycle-stream-bitrate",
             std::string("Stream Bitrate: ") + std::to_string(state.settings.streamBitrateKbps) + " kbps",
             "Cycle through the preferred video bitrate. Lower bitrates reduce bandwidth use and can help when running Sunshine and xemu on the same NATed host.",
+            true,
+          },
+          {
+            "cycle-video-decoder",
+            std::string("Video Decoder: ") + video_decoder_selection_label(state.settings.videoDecoder),
+            "Choose automatic codec negotiation or force one FFmpeg video decoder for new streams.",
             true,
           },
           {
@@ -1405,6 +1454,7 @@ namespace app {
     state.settings.xemuConsoleLoggingLevel = logging::LogLevel::none;
     state.settings.streamFramerate = DEFAULT_STREAM_FRAMERATE;
     state.settings.streamBitrateKbps = DEFAULT_STREAM_BITRATE_KBPS;
+    state.settings.videoDecoder = VideoDecoderSelection::autoDetect;
     state.settings.playAudioOnPc = false;
     state.settings.showPerformanceStats = false;
     state.settings.playAudioOnXbox = true;
@@ -1994,6 +2044,14 @@ namespace app {
       update->persistence.settingsChanged = true;
       state.shell.statusMessage = std::string("Stream bitrate set to ") + std::to_string(state.settings.streamBitrateKbps) + " kbps";
       rebuild_menu(state, "cycle-stream-bitrate");
+      return;
+    }
+    if (detailUpdate.activatedItemId == "cycle-video-decoder") {
+      cycle_video_decoder(state);
+      state.settings.dirty = true;
+      update->persistence.settingsChanged = true;
+      state.shell.statusMessage = std::string("Video decoder set to ") + video_decoder_selection_label(state.settings.videoDecoder);
+      rebuild_menu(state, "cycle-video-decoder");
       return;
     }
     if (detailUpdate.activatedItemId == "toggle-play-audio-on-pc") {

--- a/src/app/client_state.h
+++ b/src/app/client_state.h
@@ -66,6 +66,16 @@ namespace app {
   };
 
   /**
+   * @brief Video decoder preference applied to new streaming sessions.
+   */
+  enum class VideoDecoderSelection {
+    autoDetect,  ///< Let moonlight-common-c negotiate the best mutually supported video format.
+    h264,  ///< Force H.264 video decode.
+    mpeg2,  ///< Force MPEG-2/H.262 video decode.
+    h263p,  ///< Force H.263+ video decode.
+  };
+
+  /**
    * @brief Focus areas used by the two-pane settings screen.
    */
   enum class SettingsFocusArea {
@@ -321,6 +331,7 @@ namespace app {
     bool preferredVideoModeSet = false;  ///< True when preferredVideoMode contains a user-selected or default mode.
     int streamFramerate = 30;  ///< Preferred stream frame rate in frames per second.
     int streamBitrateKbps = 1000;  ///< Preferred stream bitrate in kilobits per second.
+    VideoDecoderSelection videoDecoder = VideoDecoderSelection::autoDetect;  ///< Preferred video decoder for new streams.
     bool playAudioOnPc = false;  ///< True when the host PC should continue local audio playback during streaming.
     bool showPerformanceStats = false;  ///< True when stream telemetry should be shown after streaming ends.
     bool playAudioOnXbox = true;  ///< True when the Xbox should decode and play streamed audio locally.

--- a/src/app/settings_storage.cpp
+++ b/src/app/settings_storage.cpp
@@ -127,6 +127,27 @@ namespace {
     return "full";
   }
 
+  /**
+   * @brief Convert a decoder preference to the persisted TOML token.
+   *
+   * @param selection Decoder preference to serialize.
+   * @return Stable lowercase settings value.
+   */
+  const char *video_decoder_selection_text(app::VideoDecoderSelection selection) {
+    switch (selection) {
+      case app::VideoDecoderSelection::autoDetect:
+        return "auto";
+      case app::VideoDecoderSelection::h264:
+        return "h264";
+      case app::VideoDecoderSelection::mpeg2:
+        return "mpeg2";
+      case app::VideoDecoderSelection::h263p:
+        return "h263p";
+    }
+
+    return "auto";
+  }
+
   bool try_parse_logging_level(std::string_view text, logging::LogLevel *level) {
     const std::string normalized = ascii_lowercase(text);
     if (normalized == "trace") {
@@ -186,6 +207,43 @@ namespace {
     if (normalized == "right") {
       if (placement != nullptr) {
         *placement = app::LogViewerPlacement::right;
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * @brief Parse a decoder preference from the persisted TOML token.
+   *
+   * @param text Settings value to parse.
+   * @param selection Receives the parsed decoder preference on success.
+   * @return True when @p text is a supported decoder preference.
+   */
+  bool try_parse_video_decoder_selection(std::string_view text, app::VideoDecoderSelection *selection) {
+    const std::string normalized = ascii_lowercase(text);
+    if (normalized == "auto") {
+      if (selection != nullptr) {
+        *selection = app::VideoDecoderSelection::autoDetect;
+      }
+      return true;
+    }
+    if (normalized == "h264" || normalized == "h.264") {
+      if (selection != nullptr) {
+        *selection = app::VideoDecoderSelection::h264;
+      }
+      return true;
+    }
+    if (normalized == "mpeg2" || normalized == "mpeg-2" || normalized == "h262" || normalized == "h.262") {
+      if (selection != nullptr) {
+        *selection = app::VideoDecoderSelection::mpeg2;
+      }
+      return true;
+    }
+    if (normalized == "h263p" || normalized == "h.263p" || normalized == "h263+" || normalized == "h.263+") {
+      if (selection != nullptr) {
+        *selection = app::VideoDecoderSelection::h263p;
       }
       return true;
     }
@@ -261,6 +319,34 @@ namespace {
     }
 
     append_invalid_value_warning(warnings, filePath, "ui.log_viewer_placement", "<non-string>");
+  }
+
+  /**
+   * @brief Load one decoder preference setting when present.
+   *
+   * @param settingNode TOML node to parse.
+   * @param filePath Settings file path used in warnings.
+   * @param selection Receives the parsed decoder preference on success.
+   * @param warnings Warning collection updated for invalid values.
+   */
+  void load_video_decoder_selection_setting(
+    toml::node_view<const toml::node> settingNode,
+    const std::string &filePath,
+    app::VideoDecoderSelection *selection,
+    std::vector<std::string> *warnings
+  ) {
+    if (!settingNode) {
+      return;
+    }
+
+    if (const auto videoDecoderText = settingNode.value<std::string>(); videoDecoderText) {
+      if (!try_parse_video_decoder_selection(*videoDecoderText, selection)) {
+        append_invalid_value_warning(warnings, filePath, "streaming.video_decoder", *videoDecoderText);
+      }
+      return;
+    }
+
+    append_invalid_value_warning(warnings, filePath, "streaming.video_decoder", "<non-string>");
   }
 
   /**
@@ -346,6 +432,8 @@ namespace {
     content += "# Preferred streaming parameters.\n";
     content += std::string("fps = ") + std::to_string(settings.streamFramerate) + "\n";
     content += std::string("bitrate_kbps = ") + std::to_string(settings.streamBitrateKbps) + "\n";
+    content += "# Video decoder preference. Use auto to keep normal host negotiation.\n";
+    content += std::string("video_decoder = \"") + video_decoder_selection_text(settings.videoDecoder) + "\"\n";
     content += std::string("play_audio_on_pc = ") + (settings.playAudioOnPc ? "true" : "false") + "\n";
     content += std::string("play_audio_on_xbox = ") + (settings.playAudioOnXbox ? "true" : "false") + "\n";
     content += "# Show stream telemetry after streaming ends.\n";
@@ -392,7 +480,7 @@ namespace {
   void inspect_streaming_keys(const toml::table &streamingTable, const std::string &filePath, app::LoadAppSettingsResult *result) {
     for (const auto &[rawKey, node] : streamingTable) {
       const std::string key(rawKey.str());
-      if (key == "video_width" || key == "video_height" || key == "video_bpp" || key == "video_refresh" || key == "video_mode_selected" || key == "fps" || key == "bitrate_kbps" || key == "play_audio_on_pc" || key == "play_audio_on_xbox" || key == "show_performance_stats") {
+      if (key == "video_width" || key == "video_height" || key == "video_bpp" || key == "video_refresh" || key == "video_mode_selected" || key == "fps" || key == "bitrate_kbps" || key == "video_decoder" || key == "play_audio_on_pc" || key == "play_audio_on_xbox" || key == "show_performance_stats") {
         continue;
       }
 
@@ -490,6 +578,7 @@ namespace app {
     load_boolean_setting(settingsTable["streaming"]["video_mode_selected"], filePath, "streaming.video_mode_selected", &result.settings.preferredVideoModeSet, &result.warnings);
     load_integer_setting(settingsTable["streaming"]["fps"], filePath, "streaming.fps", &result.settings.streamFramerate, &result.warnings);
     load_integer_setting(settingsTable["streaming"]["bitrate_kbps"], filePath, "streaming.bitrate_kbps", &result.settings.streamBitrateKbps, &result.warnings);
+    load_video_decoder_selection_setting(settingsTable["streaming"]["video_decoder"], filePath, &result.settings.videoDecoder, &result.warnings);
     load_boolean_setting(settingsTable["streaming"]["play_audio_on_pc"], filePath, "streaming.play_audio_on_pc", &result.settings.playAudioOnPc, &result.warnings);
     load_boolean_setting(settingsTable["streaming"]["play_audio_on_xbox"], filePath, "streaming.play_audio_on_xbox", &result.settings.playAudioOnXbox, &result.warnings);
     load_boolean_setting(settingsTable["streaming"]["show_performance_stats"], filePath, "streaming.show_performance_stats", &result.settings.showPerformanceStats, &result.warnings);

--- a/src/app/settings_storage.h
+++ b/src/app/settings_storage.h
@@ -24,6 +24,7 @@ namespace app {
     bool preferredVideoModeSet = false;  ///< True when preferredVideoMode contains a saved user preference.
     int streamFramerate = 30;  ///< Preferred stream frame rate in frames per second.
     int streamBitrateKbps = 1000;  ///< Preferred stream bitrate in kilobits per second.
+    app::VideoDecoderSelection videoDecoder = app::VideoDecoderSelection::autoDetect;  ///< Preferred video decoder for new streams.
     bool playAudioOnPc = false;  ///< True when the host PC should continue local audio playback during streaming.
     bool showPerformanceStats = false;  ///< True when stream telemetry should be shown after streaming ends.
     bool playAudioOnXbox = true;  ///< True when the Xbox should decode and play streamed audio locally.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,6 +44,7 @@ namespace {
     state.settings.preferredVideoModeSet = settings.preferredVideoModeSet;
     state.settings.streamFramerate = settings.streamFramerate;
     state.settings.streamBitrateKbps = settings.streamBitrateKbps;
+    state.settings.videoDecoder = settings.videoDecoder;
     state.settings.playAudioOnPc = settings.playAudioOnPc;
     state.settings.showPerformanceStats = settings.showPerformanceStats;
     state.settings.playAudioOnXbox = settings.playAudioOnXbox;

--- a/src/startup/video_mode.cpp
+++ b/src/startup/video_mode.cpp
@@ -39,9 +39,13 @@ namespace startup {
       return left.width == right.width && left.height == right.height;
     }
 
+    int stream_video_mode_area(const VIDEO_MODE &videoMode) {
+      return videoMode.width * videoMode.height;
+    }
+
     bool is_smaller_video_mode(const VIDEO_MODE &left, const VIDEO_MODE &right) {
-      const int leftArea = left.width * left.height;
-      if (const int rightArea = right.width * right.height; leftArea != rightArea) {
+      const int leftArea = stream_video_mode_area(left);
+      if (const int rightArea = stream_video_mode_area(right); leftArea != rightArea) {
         return leftArea < rightArea;
       }
       return left.width < right.width;

--- a/src/streaming/ffmpeg_stream_backend.cpp
+++ b/src/streaming/ffmpeg_stream_backend.cpp
@@ -56,6 +56,14 @@ namespace {
   constexpr Uint32 STREAM_VIDEO_DECODE_YIELD_MILLISECONDS = 1U;
 
   /**
+   * @brief FFmpeg codec metadata selected from one negotiated Moonlight format.
+   */
+  struct VideoCodecSelection {
+    AVCodecID codecId = AV_CODEC_ID_NONE;  ///< FFmpeg codec identifier.
+    const char *displayName = "video";  ///< Human-readable codec name for logs.
+  };
+
+  /**
    * @brief Return the backend currently receiving video callbacks.
    *
    * @return Mutable callback backend slot.
@@ -176,6 +184,37 @@ namespace {
       av_log_set_level(AV_LOG_ERROR);
       av_log_set_callback(ffmpeg_log_callback);
     });
+  }
+
+  /**
+   * @brief Resolve the FFmpeg decoder to use for one negotiated video format.
+   *
+   * @param videoFormat Moonlight negotiated video format mask.
+   * @param selection Output codec selection populated on success.
+   * @return True when the video format is supported by this backend.
+   */
+  bool select_video_codec(int videoFormat, VideoCodecSelection *selection) {
+    if (selection == nullptr) {
+      return false;
+    }
+
+    if ((videoFormat & VIDEO_FORMAT_MASK_MPEG2) != 0) {
+      selection->codecId = AV_CODEC_ID_MPEG2VIDEO;
+      selection->displayName = "MPEG-2/H.262";
+      return true;
+    }
+    if ((videoFormat & VIDEO_FORMAT_H263P) != 0) {
+      selection->codecId = AV_CODEC_ID_H263P;
+      selection->displayName = "H.263+";
+      return true;
+    }
+    if ((videoFormat & VIDEO_FORMAT_MASK_H264) != 0) {
+      selection->codecId = AV_CODEC_ID_H264;
+      selection->displayName = "H.264";
+      return true;
+    }
+
+    return false;
   }
 
   /**
@@ -378,6 +417,10 @@ namespace streaming {
     return video_.hasFrame.load();
   }
 
+  std::string FfmpegStreamBackend::active_video_decoder_name() const {
+    return video_.codecName;
+  }
+
   /**
    * @brief Return whether two SDL rectangles describe the same area.
    *
@@ -511,17 +554,19 @@ namespace streaming {
 
     cleanup_video_decoder();
 
-    if ((videoFormat & VIDEO_FORMAT_MASK_H264) == 0) {
-      logging::error("stream", "The FFmpeg backend currently supports only H.264 video streams");
+    VideoCodecSelection codecSelection;
+    if (!select_video_codec(videoFormat, &codecSelection)) {
+      logging::error("stream", "The FFmpeg backend supports H.264, MPEG-2/H.262, and H.263+ video streams");
       return -1;
     }
 
-    const AVCodec *codec = avcodec_find_decoder(AV_CODEC_ID_H264);
+    const AVCodec *codec = avcodec_find_decoder(codecSelection.codecId);
     if (codec == nullptr) {
-      logging::error("stream", "FFmpeg did not provide an H.264 decoder");
+      logging::error("stream", std::string("FFmpeg did not provide a ") + codecSelection.displayName + " decoder");
       return -1;
     }
 
+    video_.codecName = codecSelection.displayName;
     video_.codecContext = avcodec_alloc_context3(codec);
     video_.decodedFrame = av_frame_alloc();
     video_.convertedFrame = av_frame_alloc();
@@ -540,11 +585,12 @@ namespace streaming {
     video_.codecContext->skip_loop_filter = AVDISCARD_ALL;
     video_.codecContext->skip_idct = AVDISCARD_NONREF;
     if (const int openResult = avcodec_open2(video_.codecContext, codec, nullptr); openResult < 0) {
-      logging::error("stream", std::string("avcodec_open2 failed for H.264: ") + describe_ffmpeg_error(openResult));
+      logging::error("stream", std::string("avcodec_open2 failed for ") + video_.codecName + ": " + describe_ffmpeg_error(openResult));
       cleanup_video_decoder();
       return openResult;
     }
 
+    logging::info("stream", std::string("Using FFmpeg ") + video_.codecName + " software decoding");
     return 0;
   }
 
@@ -617,6 +663,7 @@ namespace streaming {
     }
     video_.renderedFrameVersion = 0;
     video_.publishedFrameVersion.store(0);
+    video_.codecName = "video";
     video_.directFramebufferDestination = SDL_Rect {0, 0, 0, 0};
     video_.directFramebufferCleared = false;
     video_.decoderStopRequested.store(false);
@@ -842,7 +889,7 @@ namespace streaming {
         return receiveResult;
       }
       if (receiveResult < 0) {
-        logging::warn("stream", std::string("avcodec_receive_frame failed for H.264: ") + describe_ffmpeg_error(receiveResult));
+        logging::warn("stream", std::string("avcodec_receive_frame failed for ") + video_.codecName + ": " + describe_ffmpeg_error(receiveResult));
         return receiveResult;
       }
 
@@ -966,7 +1013,7 @@ namespace streaming {
     }
     av_packet_unref(video_.packet);
     if (sendResult < 0) {
-      logging::warn("stream", std::string("avcodec_send_packet failed for H.264: ") + describe_ffmpeg_error(sendResult));
+      logging::warn("stream", std::string("avcodec_send_packet failed for ") + video_.codecName + ": " + describe_ffmpeg_error(sendResult));
       return DR_NEED_IDR;
     }
 

--- a/src/streaming/ffmpeg_stream_backend.h
+++ b/src/streaming/ffmpeg_stream_backend.h
@@ -34,7 +34,7 @@ namespace streaming {
    * @brief Owns the FFmpeg decode and SDL presentation state for one stream.
    *
    * The backend exposes Moonlight-compatible callback tables for video and audio,
-   * decodes H.264 video and Opus stereo audio with FFmpeg, presents the most
+   * decodes negotiated video and Opus stereo audio with FFmpeg, presents the most
    * recent decoded frame through SDL, and queues decoded PCM samples to SDL audio.
    */
   class FfmpegStreamBackend {
@@ -91,6 +91,13 @@ namespace streaming {
     bool has_decoded_video() const;
 
     /**
+     * @brief Return the human-readable active video decoder name.
+     *
+     * @return Selected video decoder name, or a generic label before setup.
+     */
+    std::string active_video_decoder_name() const;
+
+    /**
      * @brief Report whether a newly decoded video frame has not been presented yet.
      *
      * @return True when rendering would present a newer decoded frame.
@@ -113,7 +120,7 @@ namespace streaming {
     std::string build_overlay_status_line() const;
 
     /**
-     * @brief Initialize the FFmpeg H.264 decoder for Moonlight video callbacks.
+     * @brief Initialize the FFmpeg decoder for Moonlight video callbacks.
      *
      * @param videoFormat Negotiated Moonlight video format.
      * @param width Negotiated stream width.
@@ -269,6 +276,7 @@ namespace streaming {
       AVFrame *decodedFrame = nullptr;
       AVFrame *convertedFrame = nullptr;
       AVPacket *packet = nullptr;
+      const char *codecName = "video";  ///< Human-readable active video decoder name.
       SDL_Texture *texture = nullptr;
       SDL_Thread *decoderThread = nullptr;
       int textureWidth = 0;

--- a/src/streaming/session.cpp
+++ b/src/streaming/session.cpp
@@ -69,6 +69,10 @@ namespace {
   constexpr int MIN_STREAM_BITRATE_KBPS = 250;
   constexpr int MAX_STREAM_BITRATE_KBPS = 50000;
   constexpr int DEFAULT_PACKET_SIZE = 1024;
+  /**
+   * @brief Video format mask advertised to moonlight-common-c.
+   */
+  constexpr int STREAM_SUPPORTED_VIDEO_FORMATS = VIDEO_FORMAT_H264 | VIDEO_FORMAT_MPEG2 | VIDEO_FORMAT_H263P;
   constexpr std::size_t MAX_CONNECTION_PROTOCOL_MESSAGES = 24U;
   constexpr uint16_t PRESENT_GAMEPAD_MASK = 0x0001;
   constexpr uint32_t CONTROLLER_BUTTON_CAPABILITIES =
@@ -248,9 +252,11 @@ namespace {
   };
 
   struct ResolvedStreamParameters {
-    VIDEO_MODE videoMode {};
+    VIDEO_MODE presentationVideoMode {};  ///< Xbox presentation mode selected by user settings.
+    VIDEO_MODE videoMode {};  ///< Stream mode requested from the host.
     int fps = DEFAULT_STREAM_FPS;
     int bitrateKbps = DEFAULT_STREAM_BITRATE_KBPS;
+    int supportedVideoFormats = VIDEO_FORMAT_H264;
     int packetSize = DEFAULT_PACKET_SIZE;
     int streamingRemotely = STREAM_CFG_AUTO;
   };
@@ -796,6 +802,48 @@ namespace {
   }
 
   /**
+   * @brief Return the supported Moonlight format mask for one decoder preference.
+   *
+   * @param selection Decoder preference selected in settings.
+   * @return Moonlight video format mask advertised to the host.
+   */
+  int select_supported_video_formats(app::VideoDecoderSelection selection) {
+    switch (selection) {
+      case app::VideoDecoderSelection::autoDetect:
+        return STREAM_SUPPORTED_VIDEO_FORMATS;
+      case app::VideoDecoderSelection::h264:
+        return VIDEO_FORMAT_H264;
+      case app::VideoDecoderSelection::mpeg2:
+        return VIDEO_FORMAT_MPEG2;
+      case app::VideoDecoderSelection::h263p:
+        return VIDEO_FORMAT_H263P;
+    }
+
+    return STREAM_SUPPORTED_VIDEO_FORMATS;
+  }
+
+  /**
+   * @brief Describe a decoder preference for logs and waiting screens.
+   *
+   * @param selection Decoder preference selected in settings.
+   * @return Human-readable decoder preference.
+   */
+  const char *describe_video_decoder_selection(app::VideoDecoderSelection selection) {
+    switch (selection) {
+      case app::VideoDecoderSelection::autoDetect:
+        return "Auto";
+      case app::VideoDecoderSelection::h264:
+        return "H.264";
+      case app::VideoDecoderSelection::mpeg2:
+        return "MPEG-2/H.262";
+      case app::VideoDecoderSelection::h263p:
+        return "H.263+";
+    }
+
+    return "Auto";
+  }
+
+  /**
    * @brief Resolve the effective stream parameters for the next session.
    *
    * @param fallbackVideoMode Active shell output mode.
@@ -804,9 +852,11 @@ namespace {
    */
   ResolvedStreamParameters resolve_stream_parameters(const VIDEO_MODE &fallbackVideoMode, const app::SettingsState &settings) {
     ResolvedStreamParameters resolved {};
-    resolved.videoMode = select_effective_stream_video_mode(fallbackVideoMode, settings);
+    resolved.presentationVideoMode = select_effective_stream_video_mode(fallbackVideoMode, settings);
+    resolved.videoMode = resolved.presentationVideoMode;
     resolved.fps = select_stream_fps(settings);
     resolved.bitrateKbps = select_stream_bitrate_kbps(settings);
+    resolved.supportedVideoFormats = select_supported_video_formats(settings.videoDecoder);
 
     return resolved;
   }
@@ -850,7 +900,7 @@ namespace {
     context->streamConfiguration.packetSize = streamParameters.packetSize;
     context->streamConfiguration.streamingRemotely = streamParameters.streamingRemotely;
     context->streamConfiguration.audioConfiguration = AUDIO_CONFIGURATION_STEREO;
-    context->streamConfiguration.supportedVideoFormats = VIDEO_FORMAT_H264;
+    context->streamConfiguration.supportedVideoFormats = streamParameters.supportedVideoFormats;
     context->streamConfiguration.clientRefreshRateX100 = select_client_refresh_rate_x100(outputVideoMode);
     context->streamConfiguration.colorSpace = COLORSPACE_REC_601;
     context->streamConfiguration.colorRange = COLOR_RANGE_LIMITED;
@@ -1263,7 +1313,19 @@ namespace {
     return 0;
   }
 
-  streaming::StreamStatisticsSnapshot sample_stream_statistics(const StreamStartContext &context, const StreamConnectionState &connectionState) {
+  /**
+   * @brief Capture the current transport and decoder statistics.
+   *
+   * @param context Active stream configuration and host connection details.
+   * @param connectionState Mutable connection state tracked by the session loop.
+   * @param mediaBackend FFmpeg backend that owns the active decoder.
+   * @return Snapshot ready for rendering in diagnostics or end-of-stream summary.
+   */
+  streaming::StreamStatisticsSnapshot sample_stream_statistics(
+    const StreamStartContext &context,
+    const StreamConnectionState &connectionState,
+    const streaming::FfmpegStreamBackend &mediaBackend
+  ) {
     streaming::StreamStatisticsSnapshot snapshot {
       context.streamConfiguration.width,
       context.streamConfiguration.height,
@@ -1277,6 +1339,7 @@ namespace {
       -1,
       -1,
       connectionState.poorConnection.load(),
+      mediaBackend.active_video_decoder_name(),
     };
 
     uint32_t estimatedRtt = 0;
@@ -1362,7 +1425,7 @@ namespace {
       "Hold Back + Start for about one second to stop streaming.",
     };
     if (!renderedVideo) {
-      lines.emplace(lines.begin() + 2, std::string("Mode: ") + std::to_string(context.streamConfiguration.width) + "x" + std::to_string(context.streamConfiguration.height) + " @ " + std::to_string(context.streamConfiguration.fps) + " FPS | H.264 | Stereo");
+      lines.emplace(lines.begin() + 2, std::string("Mode: ") + std::to_string(context.streamConfiguration.width) + "x" + std::to_string(context.streamConfiguration.height) + " @ " + std::to_string(context.streamConfiguration.fps) + " FPS | " + (mediaBackend != nullptr ? mediaBackend->active_video_decoder_name() : std::string("video")) + " | Stereo");
       lines.emplace(lines.begin() + 4, std::string("Launch mode: ") + (context.serverInformation.rtspSessionUrl != nullptr ? "Session URL supplied by host" : "Default RTSP discovery"));
       lines.emplace(lines.begin() + 5, "Waiting for the first decoded video frame and audio output.");
     }
@@ -1631,7 +1694,7 @@ namespace streaming {
     std::string *statusMessage
   ) {
     const ResolvedStreamParameters streamParameters = resolve_stream_parameters(videoMode, settings);
-    const VIDEO_MODE streamPresentationVideoMode = select_stream_presentation_video_mode(videoMode, streamParameters.videoMode);
+    const VIDEO_MODE streamPresentationVideoMode = select_stream_presentation_video_mode(videoMode, streamParameters.presentationVideoMode);
     ScopedStreamVideoMode scopedStreamVideoMode(window, videoMode, streamPresentationVideoMode);
     const VIDEO_MODE &activeStreamVideoMode = scopedStreamVideoMode.active_video_mode();
 
@@ -1693,7 +1756,7 @@ namespace streaming {
     );
     logging::info(
       "stream",
-      std::string("Requested stream configuration | resolution=") + std::to_string(startContext.streamConfiguration.width) + "x" + std::to_string(startContext.streamConfiguration.height) + " | fps=" + std::to_string(startContext.streamConfiguration.fps) + " | bitrate=" + std::to_string(startContext.streamConfiguration.bitrate) + " kbps | packetSize=" + std::to_string(startContext.streamConfiguration.packetSize) + " | networkProfile=" + describe_streaming_remotely_mode(startContext.streamConfiguration.streamingRemotely) + " | clientRefreshX100=" + std::to_string(startContext.streamConfiguration.clientRefreshRateX100)
+      std::string("Requested stream configuration | resolution=") + std::to_string(startContext.streamConfiguration.width) + "x" + std::to_string(startContext.streamConfiguration.height) + " | fps=" + std::to_string(startContext.streamConfiguration.fps) + " | bitrate=" + std::to_string(startContext.streamConfiguration.bitrate) + " kbps | decoder=" + describe_video_decoder_selection(settings.videoDecoder) + " | packetSize=" + std::to_string(startContext.streamConfiguration.packetSize) + " | networkProfile=" + describe_streaming_remotely_mode(startContext.streamConfiguration.streamingRemotely) + " | clientRefreshX100=" + std::to_string(startContext.streamConfiguration.clientRefreshRateX100)
     );
     resources.mediaBackend.set_audio_playback_enabled(settings.playAudioOnXbox);
     logging::info("stream", std::string("Xbox audio playback ") + (settings.playAudioOnXbox ? "enabled" : "disabled for lower decode latency"));
@@ -1734,7 +1797,7 @@ namespace streaming {
     logging::info("stream", std::string(launchResult.resumedSession ? "Resumed stream for " : "Launched stream for ") + app.name + " on " + host.displayName);
     run_active_stream_loop({settings, host, app, startContext, connectionState, resources});
 
-    const streaming::StreamStatisticsSnapshot finalStatistics = sample_stream_statistics(startContext, connectionState);
+    const streaming::StreamStatisticsSnapshot finalStatistics = sample_stream_statistics(startContext, connectionState, resources.mediaBackend);
     LiStopConnection();
     active_connection_state() = nullptr;
 

--- a/src/streaming/session.h
+++ b/src/streaming/session.h
@@ -21,14 +21,14 @@ namespace streaming {
    * @brief Run one Xbox streaming session for the selected host app.
    *
    * The session launches or resumes the selected app on the host, starts the
-   * Moonlight transport runtime, decodes H.264 video and Opus audio with
+   * Moonlight transport runtime, decodes negotiated video and Opus audio with
    * FFmpeg, forwards controller input, renders the latest decoded frame with a
    * lightweight overlay, and returns once the user stops streaming or the host
    * terminates the session.
    *
    * @param window Shared SDL window reused from the shell.
    * @param videoMode Active Xbox video mode.
-   * @param settings Active shell settings that control stream resolution, bitrate, frame rate, host audio playback, and the optional end-of-stream stats summary.
+   * @param settings Active shell settings that control stream resolution, bitrate, frame rate, decoder selection, host audio playback, and the optional end-of-stream stats summary.
    * @param host Selected paired host.
    * @param app Selected host app.
    * @param clientIdentity Paired client identity used for authenticated launch requests.

--- a/src/streaming/stats_overlay.cpp
+++ b/src/streaming/stats_overlay.cpp
@@ -39,6 +39,9 @@ namespace streaming {
     {
       std::ostringstream streamLine;
       streamLine << "Stream: " << snapshot.width << "x" << snapshot.height << " @ " << snapshot.fps << " FPS";
+      if (!snapshot.videoDecoder.empty()) {
+        streamLine << " | Decoder: " << snapshot.videoDecoder;
+      }
       lines.push_back(streamLine.str());
     }
 

--- a/src/streaming/stats_overlay.h
+++ b/src/streaming/stats_overlay.h
@@ -26,6 +26,7 @@ namespace streaming {
     int videoPacketsRecovered;  ///< Video packets recovered through FEC or retransmission.
     int videoPacketsLost;  ///< Video packets permanently lost.
     bool poorConnection;  ///< True when the host flags the connection as poor.
+    std::string videoDecoder;  ///< Human-readable video decoder used for the stream.
   };
 
   /**

--- a/src/ui/shell_screen.cpp
+++ b/src/ui/shell_screen.cpp
@@ -2165,6 +2165,7 @@ namespace {
       state.settings.preferredVideoModeSet,
       state.settings.streamFramerate,
       state.settings.streamBitrateKbps,
+      state.settings.videoDecoder,
       state.settings.playAudioOnPc,
       state.settings.showPerformanceStats,
       state.settings.playAudioOnXbox,

--- a/src/ui/shell_view.cpp
+++ b/src/ui/shell_view.cpp
@@ -193,6 +193,27 @@ namespace {
     return "Logging";
   }
 
+  /**
+   * @brief Return a compact settings label for one decoder preference.
+   *
+   * @param selection Decoder preference to describe.
+   * @return User-facing decoder preference label.
+   */
+  const char *video_decoder_selection_label(app::VideoDecoderSelection selection) {
+    switch (selection) {
+      case app::VideoDecoderSelection::autoDetect:
+        return "Auto";
+      case app::VideoDecoderSelection::h264:
+        return "H.264";
+      case app::VideoDecoderSelection::mpeg2:
+        return "MPEG-2/H.262";
+      case app::VideoDecoderSelection::h263p:
+        return "H.263+";
+    }
+
+    return "Auto";
+  }
+
   std::vector<ui::ShellModalButton> keypad_buttons(const app::ClientState &state) {
     const std::vector<std::string> labels = state.addHostDraft.activeField == app::AddHostField::address ? std::vector<std::string> {"1", "2", "3", "4", "5", "6", "7", "8", "9", ".", "0"} : std::vector<std::string> {"1", "2", "3", "4", "5", "6", "7", "8", "9", "0"};
 
@@ -325,7 +346,9 @@ namespace {
       return lines;
     }
     if (state.settings.selectedCategory == app::SettingsCategory::display) {
-      lines.emplace_back("Display options will be added here.");
+      lines.push_back(std::string("Stream frame rate: ") + std::to_string(state.settings.streamFramerate) + " FPS");
+      lines.push_back(std::string("Stream bitrate: ") + std::to_string(state.settings.streamBitrateKbps) + " kbps");
+      lines.push_back(std::string("Video decoder: ") + video_decoder_selection_label(state.settings.videoDecoder));
       return lines;
     }
 

--- a/tests/unit/app/client_state_test.cpp
+++ b/tests/unit/app/client_state_test.cpp
@@ -42,6 +42,7 @@ namespace {
     EXPECT_FALSE(state.hosts.dirty);
     EXPECT_EQ(state.settings.loggingLevel, logging::LogLevel::none);
     EXPECT_EQ(state.settings.streamFramerate, 30);
+    EXPECT_EQ(state.settings.videoDecoder, app::VideoDecoderSelection::autoDetect);
   }
 
   TEST(ClientStateTest, ReplacesHostsFromPersistenceWithoutMarkingThemDirty) {
@@ -1069,6 +1070,30 @@ namespace {
     EXPECT_EQ(update.navigation.activatedItemId, "cycle-stream-framerate");
     EXPECT_EQ(state.settings.streamFramerate, 30);
     EXPECT_EQ(state.shell.statusMessage, "Stream frame rate set to 30 FPS");
+  }
+
+  TEST(ClientStateTest, DisplaySettingsCanForceVideoDecoder) {
+    app::ClientState state = app::create_initial_state();
+
+    app::handle_command(state, input::UiCommand::move_left);
+    app::handle_command(state, input::UiCommand::move_left);
+    app::handle_command(state, input::UiCommand::activate);
+    ASSERT_EQ(state.shell.activeScreen, app::ScreenId::settings);
+
+    app::handle_command(state, input::UiCommand::move_down);
+    app::handle_command(state, input::UiCommand::activate);
+    ASSERT_EQ(state.settings.selectedCategory, app::SettingsCategory::display);
+    ASSERT_EQ(state.settings.focusArea, app::SettingsFocusArea::options);
+
+    ASSERT_TRUE(state.detailMenu.select_item_by_id("cycle-video-decoder"));
+    const app::AppUpdate update = app::handle_command(state, input::UiCommand::activate);
+
+    EXPECT_EQ(update.navigation.activatedItemId, "cycle-video-decoder");
+    EXPECT_TRUE(update.persistence.settingsChanged);
+    EXPECT_EQ(state.settings.videoDecoder, app::VideoDecoderSelection::h264);
+    EXPECT_EQ(state.shell.statusMessage, "Video decoder set to H.264");
+    ASSERT_NE(state.detailMenu.selected_item(), nullptr);
+    EXPECT_EQ(state.detailMenu.selected_item()->label, "Video Decoder: H.264");
   }
 
   TEST(ClientStateTest, DisplaySettingsCanToggleXboxAudioAndEndStreamStats) {

--- a/tests/unit/app/settings_storage_test.cpp
+++ b/tests/unit/app/settings_storage_test.cpp
@@ -49,6 +49,7 @@ namespace {
       true,
       24,
       2500,
+      app::VideoDecoderSelection::mpeg2,
       true,
       true,
       true,
@@ -69,6 +70,7 @@ namespace {
     EXPECT_EQ(loadResult.settings.preferredVideoMode.refresh, 60);
     EXPECT_EQ(loadResult.settings.streamFramerate, 24);
     EXPECT_EQ(loadResult.settings.streamBitrateKbps, 2500);
+    EXPECT_EQ(loadResult.settings.videoDecoder, app::VideoDecoderSelection::mpeg2);
     EXPECT_TRUE(loadResult.settings.playAudioOnPc);
     EXPECT_TRUE(loadResult.settings.showPerformanceStats);
     EXPECT_TRUE(loadResult.settings.playAudioOnXbox);
@@ -84,6 +86,7 @@ namespace {
       true,
       15,
       500,
+      app::VideoDecoderSelection::h264,
       false,
       false,
       false,
@@ -102,6 +105,7 @@ namespace {
     EXPECT_EQ(loadResult.settings.preferredVideoMode.refresh, 60);
     EXPECT_EQ(loadResult.settings.streamFramerate, 15);
     EXPECT_EQ(loadResult.settings.streamBitrateKbps, 500);
+    EXPECT_EQ(loadResult.settings.videoDecoder, app::VideoDecoderSelection::h264);
     EXPECT_FALSE(loadResult.settings.playAudioOnXbox);
   }
 
@@ -117,6 +121,7 @@ namespace {
     EXPECT_FALSE(loadResult.settings.preferredVideoModeSet);
     EXPECT_EQ(loadResult.settings.streamFramerate, 30);
     EXPECT_EQ(loadResult.settings.streamBitrateKbps, 1000);
+    EXPECT_EQ(loadResult.settings.videoDecoder, app::VideoDecoderSelection::autoDetect);
     EXPECT_FALSE(loadResult.settings.playAudioOnPc);
     EXPECT_FALSE(loadResult.settings.showPerformanceStats);
     EXPECT_TRUE(loadResult.settings.playAudioOnXbox);
@@ -135,6 +140,7 @@ namespace {
       "[streaming]\n"
       "video_width = \"wide\"\n"
       "fps = \"fast\"\n"
+      "video_decoder = \"vp9\"\n"
       "play_audio_on_pc = \"sometimes\"\n"
       "play_audio_on_xbox = \"sometimes\"\n"
     );
@@ -148,6 +154,7 @@ namespace {
     EXPECT_EQ(loadResult.settings.logViewerPlacement, app::LogViewerPlacement::full);
     EXPECT_FALSE(loadResult.settings.preferredVideoModeSet);
     EXPECT_EQ(loadResult.settings.streamFramerate, 30);
+    EXPECT_EQ(loadResult.settings.videoDecoder, app::VideoDecoderSelection::autoDetect);
     EXPECT_FALSE(loadResult.settings.playAudioOnPc);
     EXPECT_TRUE(loadResult.settings.playAudioOnXbox);
   }

--- a/tests/unit/streaming/stats_overlay_test.cpp
+++ b/tests/unit/streaming/stats_overlay_test.cpp
@@ -23,12 +23,13 @@ namespace {
       12,
       3,
       false,
+      "H.264",
     };
 
     const std::vector<std::string> lines = streaming::build_stats_overlay_lines(snapshot);
 
     ASSERT_EQ(lines.size(), 5U);
-    EXPECT_EQ(lines[0], "Stream: 1280x720 @ 60 FPS");
+    EXPECT_EQ(lines[0], "Stream: 1280x720 @ 60 FPS | Decoder: H.264");
     EXPECT_EQ(lines[1], "Latency: RTT 18 ms | Host 6 ms | Decode 4 ms");
     EXPECT_EQ(lines[2], "Queues: Video 2 frames | Audio 15 ms");
     EXPECT_EQ(lines[3], "Video packets: 1024 rx | 12 recovered | 3 lost");


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Add user-selectable video decoder options and FFmpeg support for MPEG‑2 and H.263 family codecs.

- UI & settings: introduce VideoDecoderSelection enum, expose a cycle action and compact labels in settings, persist video_decoder in TOML, and read/write parsing helpers with validation and warnings.
- Session & negotiation: advertise supported video formats based on the selected decoder (auto / h264 / mpeg2 / h263 / h263p) when starting sessions and include decoder selection in stream logs and waiting screens.
- FFmpeg backend: enable additional parsers/decoders in build config, select an appropriate FFmpeg codec at runtime based on the negotiated format, propagate human-readable decoder names, and update decoder logging/error messages.
- Build: update CMake FFmpeg signature/profile and configure args to enable mpeg2 and h263 support.
- Overlay & stats: show active decoder in overlay and include it in statistics snapshots.
- Tests: update and add unit tests to cover default decoder, settings UI cycling, persistent loading, and overlay formatting.

These changes improve compatibility with hosts that stream non‑H.264 formats and let users force a specific software decoder when needed.


TODO:
- [x] enable encoders in build-deps - https://github.com/LizardByte/build-deps/pull/691
- [ ] enable encoders in Sunshine - https://github.com/LizardByte/Sunshine/pull/5194
- [ ] PR to moonlight-common-c - waiting on other PR to merge before submitting another
- [x] test

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [x] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [x] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
